### PR TITLE
Support mercurial-generated diffs

### DIFF
--- a/dist/parse-diff.js
+++ b/dist/parse-diff.js
@@ -121,7 +121,7 @@
     s = _.str.ltrim(s, '-');
     s = _.str.ltrim(s, '+');
     s = s.trim();
-    t = /\d{4}-\d\d-\d\d\s\d\d:\d\d:\d\d(.\d+)?\s(\+|-)\d\d\d\d/.exec(s);
+    t = /\t.*|\d{4}-\d\d-\d\d\s\d\d:\d\d:\d\d(.\d+)?\s(\+|-)\d\d\d\d/.exec(s);
     if (t) {
       s = s.substring(0, t.index).trim();
     }

--- a/parse.coffee
+++ b/parse.coffee
@@ -100,7 +100,7 @@ parseFile = (s) ->
 	s = _.str.ltrim s, '+'
 	s = s.trim()
 	# ignore possible time stamp
-	t = (/\d{4}-\d\d-\d\d\s\d\d:\d\d:\d\d(.\d+)?\s(\+|-)\d\d\d\d/).exec(s)
+	t = (/\t.*|\d{4}-\d\d-\d\d\s\d\d:\d\d:\d\d(.\d+)?\s(\+|-)\d\d\d\d/).exec(s)
 	s = s.substring(0, t.index).trim() if t
 	# ignore git prefixes a/ or b/
 	if s.match (/^(a|b)\//) then s.substr(2) else s

--- a/test/tests.coffee
+++ b/test/tests.coffee
@@ -174,3 +174,26 @@ But after they are produced,
 		file = files[0]
 		expect(file.from).to.be('lao')
 		expect(file.to).to.be('tzu')
+
+	it 'should parse hg diff output', ->
+		diff = """
+diff -r 514fc757521e lib/parsers.coffee
+--- a/lib/parsers.coffee	Thu Jul 09 00:56:36 2015 +0200
++++ b/lib/parsers.coffee	Fri Jul 10 16:23:43 2015 +0200
+@@ -43,6 +43,9 @@
+             files[file] = { added: added, deleted: deleted }
+         files
+         
++    diff: (out) ->
++        files = {}
++
+ module.exports = Parsers
+ 
+ module.exports.version = (out) ->
+"""
+		files = parse diff
+		expect(files.length).to.be(1)
+		file = files[0]
+		expect(file.lines[0].content).to.be('@@ -43,6 +43,9 @@')
+		expect(file.from).to.be('lib/parsers.coffee')
+		expect(file.to).to.be('lib/parsers.coffee')


### PR DESCRIPTION
It seems that parse-diff mostly supports mercurial-generated diffs. Here is a test to demonstrate that. However, the dates are not split from the filenames because they are different from the strict YYYY-MM-DD... format used by e.g. diff. However, it seems that both mercurial and diff uses a tab character to separate filename from date. This pull request assumes that filenames do not contain tab and simply eats from tab to end. Is it acceptable?

I am working to expand the node-hg (https://bitbucket.org/jacob4u2/node-hg) library and would like to use parse-diff to produce parsed diff output.