### PR TITLE
Structured representation of chunk head

### DIFF
--- a/dist/parse-diff.js
+++ b/dist/parse-diff.js
@@ -24,6 +24,7 @@
     start = function() {
       file = {
         lines: [],
+        chunks: [],
         deletions: 0,
         additions: 0
       };
@@ -55,13 +56,22 @@
       return file.to = parseFile(line);
     };
     chunk = function(line, match) {
-      ln_del = +match[1];
-      ln_add = +match[3];
-      return file.lines.push({
+      var newChunk, newLines, newStart, oldLines, oldStart;
+      ln_del = oldStart = +match[1];
+      oldLines = +(match[2] || 0);
+      ln_add = newStart = +match[3];
+      newLines = +(match[4] || 0);
+      newChunk = {
         type: 'chunk',
         chunk: true,
-        content: line
-      });
+        content: line,
+        oldStart: oldStart,
+        oldLines: oldLines,
+        newStart: newStart,
+        newLines: newLines
+      };
+      file.lines.push(newChunk);
+      return file.chunks.push(newChunk);
     };
     del = function(line) {
       file.lines.push({

--- a/parse.coffee
+++ b/parse.coffee
@@ -18,6 +18,7 @@ module.exports = (input) ->
 	start = ->
 		file =
 			lines: []
+			chunks: []
 			deletions: 0
 			additions: 0
 		files.push file
@@ -46,9 +47,16 @@ module.exports = (input) ->
 		file.to = parseFile line
 
 	chunk = (line, match) ->
-		ln_del = +match[1]
-		ln_add = +match[3]
-		file.lines.push {type:'chunk', chunk:true, content:line}
+		ln_del = oldStart = +match[1]
+		oldLines = +(match[2] || 0)
+		ln_add = newStart = +match[3]
+		newLines = +(match[4] || 0)
+		newChunk = {
+			type:'chunk', chunk:true, content:line,
+			oldStart, oldLines, newStart, newLines
+		}
+		file.lines.push newChunk
+		file.chunks.push newChunk
 
 	del = (line) ->
 		file.lines.push {type:'del', del:true, ln:ln_del++, content:line}

--- a/test/tests.coffee
+++ b/test/tests.coffee
@@ -110,6 +110,7 @@ index 0000000..db81be4
 		expect(file.lines.length).to.be(2)
 		expect(file.lines[0].content).to.be('@@ -0,0 +1 @@')
 		expect(file.lines[0].type).to.be('chunk')
+		expect(file.lines[0].newLines).to.be(0)
 		expect(file.lines[1].content).to.be('+line1')
 		expect(file.lines[1].type).to.be('add')
 
@@ -174,6 +175,19 @@ But after they are produced,
 		file = files[0]
 		expect(file.from).to.be('lao')
 		expect(file.to).to.be('tzu')
+		expect(file.chunks.length).to.be(2)
+		chunk0 = file.chunks[0]
+		expect(chunk0.type).to.be('chunk')
+		expect(chunk0.oldStart).to.be(1)
+		expect(chunk0.oldLines).to.be(7)
+		expect(chunk0.newStart).to.be(1)
+		expect(chunk0.newLines).to.be(6)
+		chunk1 = file.chunks[1]
+		expect(chunk1.type).to.be('chunk')
+		expect(chunk1.oldStart).to.be(9)
+		expect(chunk1.oldLines).to.be(3)
+		expect(chunk1.newStart).to.be(8)
+		expect(chunk1.newLines).to.be(6)
 
 	it 'should parse hg diff output', ->
 		diff = """


### PR DESCRIPTION
Allow easy access to parsed hunk headers. This pull request adds a new property file.chunks which points to the hunk objects in file.lines. Additionally, these grow parsed versions of the numbers as oldStart, oldLines, newStart, newLines. Like so:

``` javascript
chunks: 
   [ { type: 'chunk',
       chunk: true,
       content: '@@ -1,7 +1,6 @@',
       oldStart: 1,
       oldLines: 7,
       newStart: 1,
       newLines: 6 },
     { type: 'chunk',
       chunk: true,
       content: '@@ -9,3 +8,6 @@',
       oldStart: 9,
       oldLines: 3,
       newStart: 8,
       newLines: 6 } ],
```
