### PR TITLE
Support for deletion of an empty file

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,12 +17,15 @@ module.exports = function(input) {
   ln_del = 0;
   ln_add = 0;
   current = null;
-  start = function() {
+  start = function(line) {
     file = {
       chunks: [],
       deletions: 0,
       additions: 0
     };
+    if (line != null ? line.match(/^diff --git a\/(.+) b\/.+$/) : void 0) {
+      file.from = RegExp.$1;
+    }
     return files.push(file);
   };
   restart = function() {

--- a/parse.coffee
+++ b/parse.coffee
@@ -13,11 +13,15 @@ module.exports = (input) ->
 	ln_add = 0
 	current = null
 
-	start = ->
+	start = (line) ->
 		file =
 			chunks: []
 			deletions: 0
 			additions: 0
+
+		if line?.match /^diff --git a\/(.+) b\/.+$/
+			file.from = RegExp.$1
+
 		files.push file
 
 	restart = ->

--- a/test/tests.coffee
+++ b/test/tests.coffee
@@ -77,6 +77,20 @@ index db81be4..0000000
 		expect(file.chunks[0].changes[0].content).to.be('-line1')
 		expect(file.chunks[0].changes[1].content).to.be('-line2')
 
+	it 'should parse diff with deleted file mode line and no chunk', ->
+		diff = """
+diff --git a/test b/test
+deleted file mode 100644
+index db81be4..0000000
+"""
+		files = parse diff
+		expect(files.length).to.be(1)
+		file = files[0]
+		expect(file.deleted).to.be.true
+		expect(file.from).to.be('test')
+		expect(file.to).to.be.undefined
+		expect(file.chunks).to.have.length(0)
+
 	it 'should parse diff with single line files', ->
 		diff = """
 diff --git a/file1 b/file1


### PR DESCRIPTION
No chunk line is generated when deleting an empty file. However, I wanted to find filename of the deleted file, so have made it possible to parse starting line and extract filename.